### PR TITLE
fix: dual webkit and competing constants

### DIFF
--- a/tables_app/src/main/java/org/opendatakit/tables/activities/AbsBaseWebActivity.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/activities/AbsBaseWebActivity.java
@@ -48,12 +48,31 @@ public abstract class AbsBaseWebActivity extends AbsTableActivity implements IOd
   private static final String SESSION_VARIABLES = "sessionVariables";
 
   private static final String QUEUED_ACTIONS = "queuedActions";
-  private static final String RESPONSE_JSON = "responseJSON";
-  private LinkedList<String> queueResponseJSON = new LinkedList<>();
-  private String dispatchStringWaitingForData = null;
-  private String actionWaitingForData = null;
-  private Bundle sessionVariables = new Bundle();
-  private LinkedList<String> queuedActions = new LinkedList<>();
+  private static final String RESPONSE_JSON_MAIN = "responseJSON_main";
+  private static final String RESPONSE_JSON_SUBLIST = "responseJSON_sublist";
+
+  /**
+   * With the advent of the split screen detail-with-sublist view, we need to
+   * guard access to the data and result queues and session variable data structures.
+   *
+   * The queued data response lists need to be separated into response streams for each webkit
+   * that is active. We currently can have either one or two (detail-with-sublist) active.
+   *
+   * The dispatchString, action, and queuedActions (action results) are guarded only
+   * to ensure that they are updated concurrently and consistently. Results are expected
+   * to be read from the primary webkit (e.g., the detail webkit).
+   *
+   * The session variables bundle is a complex data structure and is guarded to ensure the two
+   * webkits don't attempt to manipulate it at the same time (it is unclear if the webkit threads
+   * will be the same thread or different).  Session variables are shared across the webkits.
+   */
+  private final Object guardCachedContent = new Object();
+  private LinkedList<String> guardedQueueResponseJSON_main = new LinkedList<>();
+  private LinkedList<String> guardedQueueResponseJSON_sublist = new LinkedList<>();
+  private String guardedDispatchStringWaitingForData = null;
+  private String guardedActionWaitingForData = null;
+  private LinkedList<String> guardedQueuedActions = new LinkedList<>();
+  private Bundle guardedSessionVariables = new Bundle();
   /**
    * Member variables that do not need to be preserved across orientation
    * changes, etc.
@@ -69,10 +88,10 @@ public abstract class AbsBaseWebActivity extends AbsTableActivity implements IOd
   /**
    * Gets the active webkit view
    *
-   * @param viewID The id for the webkit in the view heirarchy, if there are multiple
+   * @param fragmentID The id for the webkit in the view heirarchy, if there are multiple
    * @return the webkit if it was found, or else null
    */
-  public abstract ODKWebView getWebKitView(String viewID);
+  public abstract ODKWebView getWebKitView(String fragmentID);
 
   /**
    * We need to save whether we were waiting for data (a json string), our session variables, our
@@ -84,24 +103,31 @@ public abstract class AbsBaseWebActivity extends AbsTableActivity implements IOd
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
 
-    if (dispatchStringWaitingForData != null) {
-      outState.putString(DISPATCH_STRING_WAITING_FOR_DATA, dispatchStringWaitingForData);
-    }
-    if (actionWaitingForData != null) {
-      outState.putString(ACTION_WAITING_FOR_DATA, actionWaitingForData);
-    }
+    synchronized (guardCachedContent) {
+      if (guardedDispatchStringWaitingForData != null) {
+        outState.putString(DISPATCH_STRING_WAITING_FOR_DATA, guardedDispatchStringWaitingForData);
+      }
+      if (guardedActionWaitingForData != null) {
+        outState.putString(ACTION_WAITING_FOR_DATA, guardedActionWaitingForData);
+      }
 
-    outState.putBundle(SESSION_VARIABLES, sessionVariables);
+      outState.putBundle(SESSION_VARIABLES, guardedSessionVariables);
 
-    if (!queuedActions.isEmpty()) {
-      String[] actionOutcomesArray = new String[queuedActions.size()];
-      queuedActions.toArray(actionOutcomesArray);
-      outState.putStringArray(QUEUED_ACTIONS, actionOutcomesArray);
-    }
+      if (!guardedQueuedActions.isEmpty()) {
+        String[] actionOutcomesArray = new String[guardedQueuedActions.size()];
+        guardedQueuedActions.toArray(actionOutcomesArray);
+        outState.putStringArray(QUEUED_ACTIONS, actionOutcomesArray);
+      }
 
-    if (!queueResponseJSON.isEmpty()) {
-      String[] qra = queueResponseJSON.toArray(new String[queueResponseJSON.size()]);
-      outState.putStringArray(RESPONSE_JSON, qra);
+      if (!guardedQueueResponseJSON_main.isEmpty()) {
+        String[] qra = guardedQueueResponseJSON_main.toArray(new String[guardedQueueResponseJSON_main.size()]);
+        outState.putStringArray(RESPONSE_JSON_MAIN, qra);
+      }
+
+      if (!guardedQueueResponseJSON_sublist.isEmpty()) {
+        String[] qra = guardedQueueResponseJSON_sublist.toArray(new String[guardedQueueResponseJSON_sublist.size()]);
+        outState.putStringArray(RESPONSE_JSON_SUBLIST, qra);
+      }
     }
   }
 
@@ -117,34 +143,44 @@ public abstract class AbsBaseWebActivity extends AbsTableActivity implements IOd
 
     mPropertyManager = new PropertyManager(this);
 
-    if (savedInstanceState != null) {
-      // if we are restoring, assume that initialization has already occurred.
+    synchronized(guardCachedContent) {
+      if (savedInstanceState != null) {
+        // if we are restoring, assume that initialization has already occurred.
 
-      dispatchStringWaitingForData = savedInstanceState
-          .containsKey(DISPATCH_STRING_WAITING_FOR_DATA) ?
-          savedInstanceState.getString(DISPATCH_STRING_WAITING_FOR_DATA) :
-          null;
-      actionWaitingForData = savedInstanceState.containsKey(ACTION_WAITING_FOR_DATA) ?
-          savedInstanceState.getString(ACTION_WAITING_FOR_DATA) :
-          null;
+        guardedDispatchStringWaitingForData = savedInstanceState.containsKey
+            (DISPATCH_STRING_WAITING_FOR_DATA) ?
+            savedInstanceState.getString(DISPATCH_STRING_WAITING_FOR_DATA) :
+            null;
+        guardedActionWaitingForData = savedInstanceState.containsKey(ACTION_WAITING_FOR_DATA) ?
+            savedInstanceState.getString(ACTION_WAITING_FOR_DATA) :
+            null;
 
-      if (savedInstanceState.containsKey(SESSION_VARIABLES)) {
-        sessionVariables = savedInstanceState.getBundle(SESSION_VARIABLES);
-      }
-
-      if (savedInstanceState.containsKey(QUEUED_ACTIONS)) {
-        String[] actionOutcomesArray = savedInstanceState.getStringArray(QUEUED_ACTIONS);
-        queuedActions.clear();
-        if (actionOutcomesArray != null) {
-          queuedActions.addAll(Arrays.asList(actionOutcomesArray));
+        if (savedInstanceState.containsKey(SESSION_VARIABLES)) {
+          guardedSessionVariables = savedInstanceState.getBundle(SESSION_VARIABLES);
         }
-      }
 
-      if (savedInstanceState.containsKey(RESPONSE_JSON)) {
-        String[] pendingResponseJSON = savedInstanceState.getStringArray(RESPONSE_JSON);
-        queueResponseJSON.clear();
-        if (pendingResponseJSON != null) {
-          queueResponseJSON.addAll(Arrays.asList(pendingResponseJSON));
+        if (savedInstanceState.containsKey(QUEUED_ACTIONS)) {
+          String[] actionOutcomesArray = savedInstanceState.getStringArray(QUEUED_ACTIONS);
+          guardedQueuedActions.clear();
+          if (actionOutcomesArray != null) {
+            guardedQueuedActions.addAll(Arrays.asList(actionOutcomesArray));
+          }
+        }
+
+        if (savedInstanceState.containsKey(RESPONSE_JSON_MAIN)) {
+          String[] pendingResponseJSON = savedInstanceState.getStringArray(RESPONSE_JSON_MAIN);
+          guardedQueueResponseJSON_main.clear();
+          if (pendingResponseJSON != null) {
+            guardedQueueResponseJSON_main.addAll(Arrays.asList(pendingResponseJSON));
+          }
+        }
+
+        if (savedInstanceState.containsKey(RESPONSE_JSON_SUBLIST)) {
+          String[] pendingResponseJSON = savedInstanceState.getStringArray(RESPONSE_JSON_SUBLIST);
+          guardedQueueResponseJSON_sublist.clear();
+          if (pendingResponseJSON != null) {
+            guardedQueueResponseJSON_sublist.addAll(Arrays.asList(pendingResponseJSON));
+          }
         }
       }
     }
@@ -200,12 +236,16 @@ public abstract class AbsBaseWebActivity extends AbsTableActivity implements IOd
 
   @Override
   public void setSessionVariable(String elementPath, String jsonValue) {
-    sessionVariables.putString(elementPath, jsonValue);
+    synchronized (guardCachedContent) {
+      guardedSessionVariables.putString(elementPath, jsonValue);
+    }
   }
 
   @Override
   public String getSessionVariable(String elementPath) {
-    return sessionVariables.getString(elementPath);
+    synchronized (guardCachedContent) {
+      return guardedSessionVariables.getString(elementPath);
+    }
   }
 
   /**
@@ -233,8 +273,10 @@ public abstract class AbsBaseWebActivity extends AbsTableActivity implements IOd
       return "JSONException";
     }
 
-    dispatchStringWaitingForData = dispatchStructAsJSONstring;
-    actionWaitingForData = action;
+    synchronized (guardCachedContent) {
+      guardedDispatchStringWaitingForData = dispatchStructAsJSONstring;
+      guardedActionWaitingForData = action;
+    }
 
     try {
       startActivityForResult(i, RequestCodeConsts.RequestCodes.LAUNCH_DOACTION);
@@ -252,32 +294,48 @@ public abstract class AbsBaseWebActivity extends AbsTableActivity implements IOd
     ODKWebView view = getWebKitView(null);
 
     if (requestCode == RequestCodeConsts.RequestCodes.LAUNCH_DOACTION) {
-      try {
-        DoActionUtils
-            .processActivityResult(this, view, resultCode, intent, dispatchStringWaitingForData,
-                actionWaitingForData);
-      } finally {
-        dispatchStringWaitingForData = null;
-        actionWaitingForData = null;
+      String dispatchString;
+      String action;
+      synchronized (guardCachedContent) {
+        // save persisted values into a local variable
+        dispatchString = guardedDispatchStringWaitingForData;
+        action = guardedActionWaitingForData;
+
+        // clear the persisted values
+        guardedDispatchStringWaitingForData = null;
+        guardedActionWaitingForData = null;
       }
+      // DoActionUtils may invoke queueActionOutcome (gaining the lock
+      // and adding the response to the queued actions) and, if it does,
+      // it will then also signal the view that there are responses available.
+      DoActionUtils
+          .processActivityResult(this, view, resultCode, intent,
+              dispatchString,
+              action);
     }
     super.onActivityResult(requestCode, resultCode, intent);
   }
 
   public boolean isWaitingForBinaryData() {
-    return actionWaitingForData != null;
+    synchronized (guardCachedContent) {
+      return guardedActionWaitingForData != null;
+    }
   }
 
   @Override
   public void queueActionOutcome(String outcome) {
-    queuedActions.addLast(outcome);
+    synchronized (guardCachedContent) {
+      guardedQueuedActions.addLast(outcome);
+    }
   }
 
   @Override
   public void queueUrlChange(String hash) {
     try {
       String jsonEncoded = ODKFileUtils.mapper.writeValueAsString(hash);
-      queuedActions.addLast(jsonEncoded);
+      synchronized (guardCachedContent) {
+        guardedQueuedActions.addLast(jsonEncoded);
+      }
     } catch (Exception e) {
       WebLogger.getLogger(getAppName()).printStackTrace(e);
     }
@@ -285,27 +343,38 @@ public abstract class AbsBaseWebActivity extends AbsTableActivity implements IOd
 
   @Override
   public String viewFirstQueuedAction() {
-    return queuedActions.isEmpty() ? null : queuedActions.getFirst();
-  }
-
-  @Override
-  public void removeFirstQueuedAction() {
-    if (!queuedActions.isEmpty()) {
-      queuedActions.removeFirst();
+    synchronized (guardCachedContent) {
+      return guardedQueuedActions.isEmpty() ? null : guardedQueuedActions.getFirst();
     }
   }
 
   @Override
-  public void signalResponseAvailable(String responseJSON, String viewID) {
+  public void removeFirstQueuedAction() {
+    synchronized (guardCachedContent) {
+      if (!guardedQueuedActions.isEmpty()) {
+        guardedQueuedActions.removeFirst();
+      }
+    }
+  }
+
+  @Override
+  public void signalResponseAvailable(String responseJSON, String fragmentID) {
     if (responseJSON == null) {
       WebLogger.getLogger(getAppName()).e(TAG, "signalResponseAvailable -- got null responseJSON!");
     } else {
       WebLogger.getLogger(getAppName()).e(TAG,
           "signalResponseAvailable -- got " + responseJSON.length() + " long responseJSON!");
     }
+
     if (responseJSON != null) {
-      this.queueResponseJSON.push(responseJSON);
-      final ODKWebView webView = getWebKitView(viewID);
+      synchronized (guardCachedContent) {
+        if (fragmentID != null && Constants.FragmentTags.DETAIL_WITH_LIST_LIST.equals(fragmentID)) {
+          this.guardedQueueResponseJSON_sublist.push(responseJSON);
+        } else {
+          this.guardedQueueResponseJSON_main.push(responseJSON);
+        }
+      }
+      final ODKWebView webView = getWebKitView(fragmentID);
       if (webView != null) {
         runOnUiThread(new Runnable() {
           @Override
@@ -318,11 +387,20 @@ public abstract class AbsBaseWebActivity extends AbsTableActivity implements IOd
   }
 
   @Override
-  public String getResponseJSON() {
-    if (queueResponseJSON.isEmpty()) {
-      return null;
+  public String getResponseJSON(String fragmentID) {
+    synchronized (guardCachedContent) {
+      if (fragmentID != null && Constants.FragmentTags.DETAIL_WITH_LIST_LIST.equals(fragmentID)) {
+        if (guardedQueueResponseJSON_sublist.isEmpty()) {
+          return null;
+        }
+        return guardedQueueResponseJSON_sublist.removeFirst();
+      } else {
+        if (guardedQueueResponseJSON_main.isEmpty()) {
+          return null;
+        }
+        return guardedQueueResponseJSON_main.removeFirst();
+      }
     }
-    return queueResponseJSON.removeFirst();
   }
 
   @Override

--- a/tables_app/src/main/java/org/opendatakit/tables/activities/TableDisplayActivity.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/activities/TableDisplayActivity.java
@@ -481,7 +481,7 @@ public class TableDisplayActivity extends AbsBaseWebActivity
     // TODO: do we need to track the ifChanged status?
 
     String filename;
-    if (Constants.FragmentTags.DETAIL_WITH_LIST_LIST.equals(fragmentID)) {
+    if (fragmentID != null && Constants.FragmentTags.DETAIL_WITH_LIST_LIST.equals(fragmentID)) {
       filename = mCurrentSubFileName;
     } else {
       filename = mCurrentFileName;
@@ -1049,7 +1049,7 @@ public class TableDisplayActivity extends AbsBaseWebActivity
    * @param args       the arguments to give to the fragment
    */
   public void updateFragment(String fragmentID, Bundle args) {
-    if (!fragmentID.equals(Constants.FragmentTags.DETAIL_WITH_LIST_LIST)) {
+    if (fragmentID == null || !fragmentID.equals(Constants.FragmentTags.DETAIL_WITH_LIST_LIST)) {
       WebLogger.getLogger(getAppName())
           .e(TAG, "[updateFragment] Attempted to update an unsupported fragment id: " + fragmentID);
       return;
@@ -1109,7 +1109,7 @@ public class TableDisplayActivity extends AbsBaseWebActivity
 
     int queryIndex = 0;
 
-    if (Constants.FragmentTags.DETAIL_WITH_LIST_LIST.equals(fragmentID)) {
+    if (fragmentID != null && Constants.FragmentTags.DETAIL_WITH_LIST_LIST.equals(fragmentID)) {
       queryIndex = 1;
     }
 

--- a/tables_app/src/main/java/org/opendatakit/tables/fragments/AbsWebTableFragment.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/fragments/AbsWebTableFragment.java
@@ -23,6 +23,7 @@ import android.view.ViewGroup;
 import org.opendatakit.activities.BaseActivity;
 import org.opendatakit.logging.WebLogger;
 import org.opendatakit.tables.R;
+import org.opendatakit.tables.activities.IOdkTablesActivity;
 import org.opendatakit.tables.application.Tables;
 import org.opendatakit.tables.views.webkits.OdkTablesWebView;
 
@@ -76,6 +77,8 @@ public abstract class AbsWebTableFragment extends AbsTableDisplayFragment implem
 
     if (getView() != null) {
       setWebKitVisibility();
+      WebLogger.getLogger(((IOdkTablesActivity) getActivity()).getAppName())
+          .d(TAG, "reloadPage " + getWebKit().getContainerFragmentID());
       getWebKit().reloadPage();
     }
   }

--- a/tables_app/src/main/java/org/opendatakit/tables/utils/Constants.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/utils/Constants.java
@@ -15,6 +15,8 @@
  */
 package org.opendatakit.tables.utils;
 
+import org.opendatakit.views.OdkData;
+
 import android.graphics.Color;
 
 /**
@@ -95,17 +97,17 @@ public final class Constants {
     /**
      * Intent key to store filenames
      */
-    public static final String FILE_NAME = "filename";
+    public static final String FILE_NAME = OdkData.IntentKeys.FILE_NAME;
     // should be instanceID?    public static final String ROW_ID = "rowId";
     /**
      * The name of the graph view that should be displayed.
      */
-    public static final String ELEMENT_KEY = "elementKey";
+    public static final String ELEMENT_KEY = OdkData.IntentKeys.ELEMENT_KEY;
     /**
      * Intent key for storing a color rule type (column, table, status column) in a bundle
      * Only used in IntentUtil
      */
-    public static final String COLOR_RULE_TYPE = "colorRuleType";
+    public static final String COLOR_RULE_TYPE = OdkData.IntentKeys.COLOR_RULE_TYPE;
     /**
      * The TableLevelPreferencesActivity.FragmentType that should be
      * displayed when launching a TableLevelPreferencesActivity.
@@ -116,7 +118,7 @@ public final class Constants {
      * complex query than permissible by the simple query object. Must conform
      * to the expectations of simpleQuery() AIDL.
      */
-    public static final String SQL_WHERE = "sqlWhereClause";
+    public static final String SQL_WHERE = OdkData.IntentKeys.SQL_WHERE;
 
     /**
      * Used when launching a TableDisplayActivity to a SpreadsheetView when you want to pass
@@ -130,24 +132,24 @@ public final class Constants {
      * This allows for integer, numeric, boolean and string values to be
      * passed through to the SQLite layer.
      */
-    public static final String SQL_SELECTION_ARGS = "sqlSelectionArgs";
+    public static final String SQL_SELECTION_ARGS = OdkData.IntentKeys.SQL_SELECTION_ARGS;
     /**
      * An array of strings giving the group by columns. What was formerly
      * 'overview' mode is a non-null groupBy list.
      */
-    public static final String SQL_GROUP_BY_ARGS = "sqlGroupByArgs";
+    public static final String SQL_GROUP_BY_ARGS = OdkData.IntentKeys.SQL_GROUP_BY_ARGS;
     /**
      * The having clause, if present
      */
-    public static final String SQL_HAVING = "sqlHavingClause";
+    public static final String SQL_HAVING = OdkData.IntentKeys.SQL_HAVING;
     /**
      * The order by column. NOTE: restricted to a single column
      */
-    public static final String SQL_ORDER_BY_ELEMENT_KEY = "sqlOrderByElementKey";
+    public static final String SQL_ORDER_BY_ELEMENT_KEY = OdkData.IntentKeys.SQL_ORDER_BY_ELEMENT_KEY;
     /**
      * The order by direction (ASC or DESC)
      */
-    public static final String SQL_ORDER_BY_DIRECTION = "sqlOrderByDirection";
+    public static final String SQL_ORDER_BY_DIRECTION = OdkData.IntentKeys.SQL_ORDER_BY_DIRECTION;
 
     private IntentKeys() {
     }


### PR DESCRIPTION
split data result queue into one for detail view and one for sublist. Add synchronized block to all persistent content to ensure that the threads from the two webkits don't interleave when accessing the content. Clear the action and dispatch strings before signaling the webkit that a doAction result is available. This avoids a potential error if the webkit calls back into the Java layer before these fields can be cleared. Share these important string constants, don't re-declare them.

This is dependent upon #https://github.com/opendatakit/androidcommon/pull/17