### PR TITLE
Tables table sorting feature

### DIFF
--- a/tables_app/src/main/java/org/opendatakit/tables/activities/MainActivity.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/activities/MainActivity.java
@@ -302,21 +302,21 @@ public class MainActivity extends AbsBaseWebActivity
         Bundle bundle = new Bundle();
         String defaultValue = Constants.TABLE_SORT_ORDER.SORT_ASC.getCorrespondingName();
         String sortingOrder = defaultValue;
-        if(mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER ) != null
-                || (!mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER ).equals("")) )
-          sortingOrder = mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER );
+        if(mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER) != null
+                || (!mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER).equals("")) )
+          sortingOrder = mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER);
 
-        bundle.putSerializable(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER,  Constants.TABLE_SORT_ORDER.getCorrespondingEnum(sortingOrder)  );
+        bundle.putSerializable(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER,  Constants.TABLE_SORT_ORDER.getCorrespondingEnum(sortingOrder)  );
         newFragment.setArguments(bundle);
       }
       else {
         String defaultValue = Constants.TABLE_SORT_ORDER.SORT_ASC.getCorrespondingName();
         String sortingOrder = defaultValue;
-        if(mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER ) != null
-                || (!mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER ).equals("")) )
-          sortingOrder = mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER );
+        if(mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER) != null
+                || (!mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER).equals("")) )
+          sortingOrder = mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER);
 
-        newFragment.getArguments().putSerializable(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER,  Constants.TABLE_SORT_ORDER.getCorrespondingEnum(sortingOrder)  );
+        newFragment.getArguments().putSerializable(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER,  Constants.TABLE_SORT_ORDER.getCorrespondingEnum(sortingOrder)  );
         newFragment.onResume();
       }
       break;
@@ -397,9 +397,9 @@ public class MainActivity extends AbsBaseWebActivity
       menuInflater.inflate(R.menu.table_manager, menu);
       String defaultValue = Constants.TABLE_SORT_ORDER.SORT_ASC.getCorrespondingName();
       String sortingOrder = defaultValue;
-      if(mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER ) != null
-              || (!mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER ).equals("")) )
-        sortingOrder = mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER );
+      if(mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER) != null
+              || (!mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER).equals("")) )
+        sortingOrder = mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER);
       if( Constants.TABLE_SORT_ORDER.getCorrespondingEnum(sortingOrder) ==   Constants.TABLE_SORT_ORDER.SORT_ASC )
         menu.findItem(R.id.menu_sort_name_asc).setChecked(true);
       else
@@ -481,12 +481,12 @@ public class MainActivity extends AbsBaseWebActivity
       return true;
       case R.id.menu_sort_name_asc:
         mPropSingleton.setProperties( Collections.singletonMap(
-                CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER  , Constants.TABLE_SORT_ORDER.SORT_ASC.getCorrespondingName() ));
+                CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER, Constants.TABLE_SORT_ORDER.SORT_ASC.getCorrespondingName() ));
         swapScreens(activeScreenType);
        return true;
       case R.id.menu_sort_name_desc:
         mPropSingleton.setProperties( Collections.singletonMap(
-                CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER  , Constants.TABLE_SORT_ORDER.SORT_DESC.getCorrespondingName() ));
+                CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER, Constants.TABLE_SORT_ORDER.SORT_DESC.getCorrespondingName() ));
         swapScreens(activeScreenType);
        return true;
       default:

--- a/tables_app/src/main/java/org/opendatakit/tables/activities/MainActivity.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/activities/MainActivity.java
@@ -300,21 +300,23 @@ public class MainActivity extends AbsBaseWebActivity
       if (newFragment == null) {
         newFragment = new TableManagerFragment();
         Bundle bundle = new Bundle();
-        int defaultValue = Constants.TABLE_SORT_ORDER.SORT_ASC.getValue();
-        int sortingOrder = defaultValue;
-        if(mPropSingleton.getIntegerProperty(Constants.PERF_SORT_BY_ORDER ) != null)
-          sortingOrder = mPropSingleton.getIntegerProperty(Constants.PERF_SORT_BY_ORDER );
+        String defaultValue = Constants.TABLE_SORT_ORDER.SORT_ASC.getCorrespondingName();
+        String sortingOrder = defaultValue;
+        if(mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER ) != null
+                || (!mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER ).equals("")) )
+          sortingOrder = mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER );
 
-        bundle.putSerializable(Constants.PERF_SORT_BY_ORDER,  Constants.TABLE_SORT_ORDER.getCorrespondingEnum(sortingOrder)  );
+        bundle.putSerializable(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER,  Constants.TABLE_SORT_ORDER.getCorrespondingEnum(sortingOrder)  );
         newFragment.setArguments(bundle);
       }
       else {
-        int defaultValue = Constants.TABLE_SORT_ORDER.SORT_ASC.getValue();
-        int sortingOrder = defaultValue;
-        if(mPropSingleton.getIntegerProperty(Constants.PERF_SORT_BY_ORDER ) != null )
-          sortingOrder = mPropSingleton.getIntegerProperty(Constants.PERF_SORT_BY_ORDER );
+        String defaultValue = Constants.TABLE_SORT_ORDER.SORT_ASC.getCorrespondingName();
+        String sortingOrder = defaultValue;
+        if(mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER ) != null
+                || (!mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER ).equals("")) )
+          sortingOrder = mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER );
 
-        newFragment.getArguments().putSerializable(Constants.PERF_SORT_BY_ORDER,  Constants.TABLE_SORT_ORDER.getCorrespondingEnum(sortingOrder)  );
+        newFragment.getArguments().putSerializable(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER,  Constants.TABLE_SORT_ORDER.getCorrespondingEnum(sortingOrder)  );
         newFragment.onResume();
       }
       break;
@@ -393,10 +395,11 @@ public class MainActivity extends AbsBaseWebActivity
       menuInflater.inflate(R.menu.web_view_activity, menu);
     } else if (activeScreenType == ScreenType.TABLE_MANAGER_SCREEN) {
       menuInflater.inflate(R.menu.table_manager, menu);
-      int defaultValue = Constants.TABLE_SORT_ORDER.SORT_ASC.getValue();
-      int sortingOrder = defaultValue;
-      if(mPropSingleton.getIntegerProperty(Constants.PERF_SORT_BY_ORDER ) != null)
-        sortingOrder = mPropSingleton.getIntegerProperty(Constants.PERF_SORT_BY_ORDER );
+      String defaultValue = Constants.TABLE_SORT_ORDER.SORT_ASC.getCorrespondingName();
+      String sortingOrder = defaultValue;
+      if(mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER ) != null
+              || (!mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER ).equals("")) )
+        sortingOrder = mPropSingleton.getProperty(CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER );
       if( Constants.TABLE_SORT_ORDER.getCorrespondingEnum(sortingOrder) ==   Constants.TABLE_SORT_ORDER.SORT_ASC )
         menu.findItem(R.id.menu_sort_name_asc).setChecked(true);
       else
@@ -478,12 +481,12 @@ public class MainActivity extends AbsBaseWebActivity
       return true;
       case R.id.menu_sort_name_asc:
         mPropSingleton.setProperties( Collections.singletonMap(
-                Constants.PERF_SORT_BY_ORDER  , Integer.toString(Constants.TABLE_SORT_ORDER.SORT_ASC.getValue() )));
+                CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER  , Constants.TABLE_SORT_ORDER.SORT_ASC.getCorrespondingName() ));
         swapScreens(activeScreenType);
        return true;
       case R.id.menu_sort_name_desc:
         mPropSingleton.setProperties( Collections.singletonMap(
-                Constants.PERF_SORT_BY_ORDER  , Integer.toString(Constants.TABLE_SORT_ORDER.SORT_DESC.getValue() )));
+                CommonToolProperties.KEY_PERF_TABLES_SORT_BY_ORDER  , Constants.TABLE_SORT_ORDER.SORT_DESC.getCorrespondingName() ));
         swapScreens(activeScreenType);
        return true;
       default:

--- a/tables_app/src/main/java/org/opendatakit/tables/activities/MainActivity.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/activities/MainActivity.java
@@ -390,10 +390,10 @@ public class MainActivity extends AbsBaseWebActivity
     } else if (activeScreenType == ScreenType.TABLE_MANAGER_SCREEN) {
       menuInflater.inflate(R.menu.table_manager, menu);
       String sortingOrder = mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER);
-      if( sortingOrder.equalsIgnoreCase( Constants.TABLE_SORT_ORDER.SORT_ASC.name() ) )
-        menu.findItem(R.id.menu_sort_name_asc).setChecked(true);
-      else
+      if( sortingOrder != null && sortingOrder.equalsIgnoreCase( Constants.TABLE_SORT_ORDER.SORT_DESC.name() ) )
         menu.findItem(R.id.menu_sort_name_desc).setChecked(true);
+      else
+        menu.findItem(R.id.menu_sort_name_asc).setChecked(true);
     }
     lastMenuType = activeScreenType;
 

--- a/tables_app/src/main/java/org/opendatakit/tables/activities/MainActivity.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/activities/MainActivity.java
@@ -65,6 +65,11 @@ import java.util.Collections;
 public class MainActivity extends AbsBaseWebActivity
     implements DatabaseConnectionListener, IInitResumeActivity {
 
+  public interface UXNotifyListener
+  {
+    public void notifyUIChanges();
+  }
+
   // Used for logging
   private static final String TAG = MainActivity.class.getSimpleName();
   private static final String CURRENT_FRAGMENT = "currentFragment";
@@ -297,27 +302,16 @@ public class MainActivity extends AbsBaseWebActivity
     switch (newScreenType) {
     case TABLE_MANAGER_SCREEN:
       newFragment = mgr.findFragmentByTag(newScreenType.name());
+      String sortingOrder = mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER);
       if (newFragment == null) {
         newFragment = new TableManagerFragment();
         Bundle bundle = new Bundle();
-        String defaultValue = Constants.TABLE_SORT_ORDER.SORT_ASC.getCorrespondingName();
-        String sortingOrder = defaultValue;
-        if(mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER) != null
-                || (!mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER).equals("")) )
-          sortingOrder = mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER);
-
-        bundle.putSerializable(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER,  Constants.TABLE_SORT_ORDER.getCorrespondingEnum(sortingOrder)  );
+        bundle.putString(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER, sortingOrder  );
         newFragment.setArguments(bundle);
       }
       else {
-        String defaultValue = Constants.TABLE_SORT_ORDER.SORT_ASC.getCorrespondingName();
-        String sortingOrder = defaultValue;
-        if(mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER) != null
-                || (!mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER).equals("")) )
-          sortingOrder = mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER);
-
-        newFragment.getArguments().putSerializable(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER,  Constants.TABLE_SORT_ORDER.getCorrespondingEnum(sortingOrder)  );
-        newFragment.onResume();
+        newFragment.getArguments().putString(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER, sortingOrder  );
+        ((TableManagerFragment) newFragment).notifyUIChanges();
       }
       break;
     case WEBVIEW_SCREEN:
@@ -395,12 +389,8 @@ public class MainActivity extends AbsBaseWebActivity
       menuInflater.inflate(R.menu.web_view_activity, menu);
     } else if (activeScreenType == ScreenType.TABLE_MANAGER_SCREEN) {
       menuInflater.inflate(R.menu.table_manager, menu);
-      String defaultValue = Constants.TABLE_SORT_ORDER.SORT_ASC.getCorrespondingName();
-      String sortingOrder = defaultValue;
-      if(mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER) != null
-              || (!mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER).equals("")) )
-        sortingOrder = mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER);
-      if( Constants.TABLE_SORT_ORDER.getCorrespondingEnum(sortingOrder) ==   Constants.TABLE_SORT_ORDER.SORT_ASC )
+      String sortingOrder = mPropSingleton.getProperty(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER);
+      if( sortingOrder.equalsIgnoreCase( Constants.TABLE_SORT_ORDER.SORT_ASC.name() ) )
         menu.findItem(R.id.menu_sort_name_asc).setChecked(true);
       else
         menu.findItem(R.id.menu_sort_name_desc).setChecked(true);
@@ -479,17 +469,17 @@ public class MainActivity extends AbsBaseWebActivity
         Toast.makeText(this, R.string.sync_not_found, Toast.LENGTH_LONG).show();
       }
       return true;
-      case R.id.menu_sort_name_asc:
-        mPropSingleton.setProperties( Collections.singletonMap(
-                CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER, Constants.TABLE_SORT_ORDER.SORT_ASC.getCorrespondingName() ));
-        swapScreens(activeScreenType);
-       return true;
-      case R.id.menu_sort_name_desc:
-        mPropSingleton.setProperties( Collections.singletonMap(
-                CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER, Constants.TABLE_SORT_ORDER.SORT_DESC.getCorrespondingName() ));
-        swapScreens(activeScreenType);
-       return true;
-      default:
+    case R.id.menu_sort_name_asc:
+      mPropSingleton.setProperties( Collections.singletonMap(
+                CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER, Constants.TABLE_SORT_ORDER.SORT_ASC.name() ));
+      swapScreens(activeScreenType);
+      return true;
+    case R.id.menu_sort_name_desc:
+      mPropSingleton.setProperties( Collections.singletonMap(
+                CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER, Constants.TABLE_SORT_ORDER.SORT_DESC.name() ));
+      swapScreens(activeScreenType);
+      return true;
+    default:
       return super.onOptionsItemSelected(item);
     }
   }

--- a/tables_app/src/main/java/org/opendatakit/tables/fragments/TableManagerFragment.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/fragments/TableManagerFragment.java
@@ -116,7 +116,7 @@ public class TableManagerFragment extends ListFragment implements DatabaseConnec
     List<TableNameStruct> tableNameStructs = new ArrayList<>();
 
     if(this.getArguments() != null)
-      fragSortOrder = (Constants.TABLE_SORT_ORDER)this.getArguments().getSerializable(Constants.PERF_SORT_BY_ORDER);
+      fragSortOrder = (Constants.TABLE_SORT_ORDER)this.getArguments().getSerializable(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER);
 
     if (Tables.getInstance().getDatabase() != null) {
 

--- a/tables_app/src/main/java/org/opendatakit/tables/fragments/TableManagerFragment.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/fragments/TableManagerFragment.java
@@ -44,6 +44,7 @@ import org.opendatakit.properties.CommonToolProperties;
 import org.opendatakit.properties.PropertiesSingleton;
 import org.opendatakit.tables.R;
 import org.opendatakit.tables.activities.AbsBaseActivity;
+import org.opendatakit.tables.activities.MainActivity;
 import org.opendatakit.tables.activities.TableDisplayActivity;
 import org.opendatakit.tables.activities.TableLevelPreferencesActivity;
 import org.opendatakit.tables.application.Tables;
@@ -61,15 +62,13 @@ import java.util.List;
  * A fragment that displays a list of tables with a table actions button to the right of each of
  * them. The default fragment created in MainMenuActivity if there is no splash screen set
  */
-public class TableManagerFragment extends ListFragment implements DatabaseConnectionListener {
+public class TableManagerFragment extends ListFragment implements DatabaseConnectionListener, MainActivity.UXNotifyListener {
 
   private static final String TAG = TableManagerFragment.class.getSimpleName();
 
   private static final int ID = R.layout.fragment_table_list;
 
   private TableNameStructAdapter mTpAdapter = null;
-
-  private Constants.TABLE_SORT_ORDER fragSortOrder = null;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -114,9 +113,7 @@ public class TableManagerFragment extends ListFragment implements DatabaseConnec
     DbHandle db = null;
 
     List<TableNameStruct> tableNameStructs = new ArrayList<>();
-
-    if(this.getArguments() != null)
-      fragSortOrder = (Constants.TABLE_SORT_ORDER)this.getArguments().getSerializable(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER);
+    final Constants.TABLE_SORT_ORDER fragSortOrder = getArguments() == null ? null : Constants.TABLE_SORT_ORDER.valueOf(this.getArguments().getString(CommonToolProperties.KEY_PREF_TABLES_SORT_BY_ORDER) );
 
     if (Tables.getInstance().getDatabase() != null) {
 
@@ -156,11 +153,13 @@ public class TableManagerFragment extends ListFragment implements DatabaseConnec
         @Override
         public int compare(TableNameStruct o1, TableNameStruct o2)
         {
-          return o1.getLocalizedDisplayName().compareTo(o2.getLocalizedDisplayName());
+          if( fragSortOrder == Constants.TABLE_SORT_ORDER.SORT_DESC )
+            return o2.getLocalizedDisplayName().compareTo(o1.getLocalizedDisplayName());
+          else
+            return o1.getLocalizedDisplayName().compareTo(o2.getLocalizedDisplayName());
         }
       });
-      if(fragSortOrder == Constants.TABLE_SORT_ORDER.SORT_DESC)
-        Collections.reverse(tableNameStructs);
+
     }
 
     if (mTpAdapter == null) {
@@ -291,5 +290,9 @@ public class TableManagerFragment extends ListFragment implements DatabaseConnec
   public void databaseUnavailable() {
     this.updateTableIdList();
   }
-
+  
+  @Override
+  public void notifyUIChanges() {
+    updateTableIdList();
+  }
 }

--- a/tables_app/src/main/java/org/opendatakit/tables/fragments/TableManagerFragment.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/fragments/TableManagerFragment.java
@@ -48,10 +48,13 @@ import org.opendatakit.tables.activities.TableDisplayActivity;
 import org.opendatakit.tables.activities.TableLevelPreferencesActivity;
 import org.opendatakit.tables.application.Tables;
 import org.opendatakit.tables.utils.ActivityUtil;
+import org.opendatakit.tables.utils.Constants;
 import org.opendatakit.tables.utils.TableNameStruct;
 import org.opendatakit.tables.views.components.TableNameStructAdapter;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -65,6 +68,8 @@ public class TableManagerFragment extends ListFragment implements DatabaseConnec
   private static final int ID = R.layout.fragment_table_list;
 
   private TableNameStructAdapter mTpAdapter = null;
+
+  private Constants.TABLE_SORT_ORDER fragSortOrder = null;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -101,7 +106,6 @@ public class TableManagerFragment extends ListFragment implements DatabaseConnec
     }
 
     String appName = baseActivity.getAppName();
-
     PropertiesSingleton props = CommonToolProperties.get(getActivity().getApplication(), appName);
     String userSelectedDefaultLocale = props.getUserSelectedDefaultLocale();
 
@@ -109,6 +113,9 @@ public class TableManagerFragment extends ListFragment implements DatabaseConnec
     DbHandle db = null;
 
     List<TableNameStruct> tableNameStructs = new ArrayList<>();
+
+    if(this.getArguments() != null)
+      fragSortOrder = (Constants.TABLE_SORT_ORDER)this.getArguments().getSerializable(Constants.PERF_SORT_BY_ORDER);
 
     if (Tables.getInstance().getDatabase() != null) {
 
@@ -141,6 +148,18 @@ public class TableManagerFragment extends ListFragment implements DatabaseConnec
           }
         }
       }
+    }
+    if(fragSortOrder != null)
+    {
+      Collections.sort(tableNameStructs, new Comparator<TableNameStruct>() {
+        @Override
+        public int compare(TableNameStruct o1, TableNameStruct o2)
+        {
+          return o1.getLocalizedDisplayName().compareTo(o2.getLocalizedDisplayName());
+        }
+      });
+      if(fragSortOrder == Constants.TABLE_SORT_ORDER.SORT_DESC)
+        Collections.reverse(tableNameStructs);
     }
 
     if (mTpAdapter == null) {

--- a/tables_app/src/main/java/org/opendatakit/tables/fragments/TableManagerFragment.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/fragments/TableManagerFragment.java
@@ -105,7 +105,6 @@ public class TableManagerFragment extends ListFragment implements DatabaseConnec
     }
 
     String appName = baseActivity.getAppName();
-    
     PropertiesSingleton props = CommonToolProperties.get(getActivity().getApplication(), appName);
     String userSelectedDefaultLocale = props.getUserSelectedDefaultLocale();
 
@@ -147,8 +146,7 @@ public class TableManagerFragment extends ListFragment implements DatabaseConnec
         }
       }
     }
-    if(fragSortOrder != null)
-    {
+    if(fragSortOrder != null) {
       Collections.sort(tableNameStructs, new Comparator<TableNameStruct>() {
         @Override
         public int compare(TableNameStruct o1, TableNameStruct o2)
@@ -159,7 +157,6 @@ public class TableManagerFragment extends ListFragment implements DatabaseConnec
             return o1.getLocalizedDisplayName().compareTo(o2.getLocalizedDisplayName());
         }
       });
-
     }
 
     if (mTpAdapter == null) {

--- a/tables_app/src/main/java/org/opendatakit/tables/fragments/TableManagerFragment.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/fragments/TableManagerFragment.java
@@ -106,6 +106,7 @@ public class TableManagerFragment extends ListFragment implements DatabaseConnec
     }
 
     String appName = baseActivity.getAppName();
+    
     PropertiesSingleton props = CommonToolProperties.get(getActivity().getApplication(), appName);
     String userSelectedDefaultLocale = props.getUserSelectedDefaultLocale();
 

--- a/tables_app/src/main/java/org/opendatakit/tables/utils/Constants.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/utils/Constants.java
@@ -337,9 +337,10 @@ public final class Constants {
     }
   }
 
-    public enum TABLE_SORT_ORDER
-    {
-      SORT_ASC, SORT_DESC;
-    }
-
+  /**
+   * Enum for storing SORT ORDER for Table's table list.
+   */
+  public enum TABLE_SORT_ORDER {
+      SORT_ASC, SORT_DESC
+  }
 }

--- a/tables_app/src/main/java/org/opendatakit/tables/utils/Constants.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/utils/Constants.java
@@ -335,8 +335,7 @@ public final class Constants {
      */
     private JavaScriptHandles() {
     }
-
-    }
+  }
     public static final String PERF_SORT_BY_ORDER = "org.opendatakit.tables.fragment.sortbyorder";
 
     public enum TABLE_SORT_ORDER

--- a/tables_app/src/main/java/org/opendatakit/tables/utils/Constants.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/utils/Constants.java
@@ -336,17 +336,15 @@ public final class Constants {
     private JavaScriptHandles() {
     }
   }
-    public static final String PERF_SORT_BY_ORDER = "org.opendatakit.tables.fragment.sortbyorder";
 
     public enum TABLE_SORT_ORDER
     {
-      SORT_ASC(0), SORT_DESC(1);
-      private final int value;
-      TABLE_SORT_ORDER(int value) { this.value = value; }
-      public int getValue() { return value; }
-      public static TABLE_SORT_ORDER getCorrespondingEnum(int table_sort_order)
+      SORT_ASC, SORT_DESC;
+
+      public String getCorrespondingName() { return this.name(); }
+      public static TABLE_SORT_ORDER getCorrespondingEnum(String table_sort_order)
       {
-        if(table_sort_order ==  0)
+        if( table_sort_order.equalsIgnoreCase( SORT_ASC.name() ) )
           return SORT_ASC;
         else
           return SORT_DESC;

--- a/tables_app/src/main/java/org/opendatakit/tables/utils/Constants.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/utils/Constants.java
@@ -335,6 +335,23 @@ public final class Constants {
      */
     private JavaScriptHandles() {
     }
-  }
+
+    }
+    public static final String PERF_SORT_BY_ORDER = "org.opendatakit.tables.fragment.sortbyorder";
+
+    public enum TABLE_SORT_ORDER
+    {
+      SORT_ASC(0), SORT_DESC(1);
+      private final int value;
+      TABLE_SORT_ORDER(int value) { this.value = value; }
+      public int getValue() { return value; }
+      public static TABLE_SORT_ORDER getCorrespondingEnum(int table_sort_order)
+      {
+        if(table_sort_order ==  0)
+          return SORT_ASC;
+        else
+          return SORT_DESC;
+      }
+    }
 
 }

--- a/tables_app/src/main/java/org/opendatakit/tables/utils/Constants.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/utils/Constants.java
@@ -340,15 +340,6 @@ public final class Constants {
     public enum TABLE_SORT_ORDER
     {
       SORT_ASC, SORT_DESC;
-
-      public String getCorrespondingName() { return this.name(); }
-      public static TABLE_SORT_ORDER getCorrespondingEnum(String table_sort_order)
-      {
-        if( table_sort_order.equalsIgnoreCase( SORT_ASC.name() ) )
-          return SORT_ASC;
-        else
-          return SORT_DESC;
-      }
     }
 
 }

--- a/tables_app/src/main/res/menu/table_manager.xml
+++ b/tables_app/src/main/res/menu/table_manager.xml
@@ -21,6 +21,17 @@
             android:icon="@drawable/ic_settings_black_24dp"
             android:title="@string/preferences"
             android:showAsAction="ifRoom"/>
+    <item android:title="@string/sort_order_title"
+          android:showAsAction="ifRoom">
+        <menu>
+            <group android:checkableBehavior="single">
+                <item android:title="@string/sort_order_name_asc"
+                    android:id="@+id/menu_sort_name_asc"/>
+                <item android:title="@string/sort_order_name_desc"
+                    android:id="@+id/menu_sort_name_desc"/>
+            </group>
+        </menu>
+    </item>
     <item
             android:id="@+id/menu_table_about"
             android:icon="@drawable/ic_info_outline_black_24dp"

--- a/tables_app/src/main/res/values/strings.xml
+++ b/tables_app/src/main/res/values/strings.xml
@@ -443,4 +443,7 @@
     <string name="heading">Heading: %1$s° %2$s</string>
     <string name="navigate_arrive_button">Arrive</string>
     <string name="navigate_cancel_button">Cancel</string>
+    <string name="sort_order_name_asc">Name (Alphabetical)</string>
+    <string name="sort_order_name_desc">Name (Reverse Alphabetical)</string>
+    <string name="sort_order_title">Sort By</string>
 </resources>


### PR DESCRIPTION
This is in reference to issue : opendatakit/opendatakit#1377
User can sort tables in List View by "Name" as per his choice i.e in ascending and descending order. Tables has another field "TableId" which I skipped because sorting via TableId would have given same ordering.