### PR TITLE
Replace support-v13 ActivityCompat with support-v4 ActivityCompat

### DIFF
--- a/tables_app/build.gradle
+++ b/tables_app/build.gradle
@@ -120,6 +120,7 @@ dependencies {
     implementation fileTree(include: '*.jar', dir: 'libs')
     implementation 'com.android.support:support-annotations:27.1.0'
     implementation 'com.android.support:support-v13:27.1.0'
+    implementation 'com.android.support:support-v4:27.1.0'
     implementation 'com.github.Todd-Davies:ProgressWheel:1.2'
     implementation 'com.google.firebase:firebase-core:11.8.0'
     implementation ('com.crashlytics.sdk.android:crashlytics:2.9.1@aar') {

--- a/tables_app/src/main/java/org/opendatakit/tables/activities/TableDisplayActivity.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/activities/TableDisplayActivity.java
@@ -27,7 +27,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
-import android.support.v13.app.ActivityCompat;
+import android.support.v4.app.ActivityCompat;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;


### PR DESCRIPTION
ActivityCompat is deprecated in support library 27.1.0 and replaced by ActivityCompat in support-v4.
This pull request replaces usage of v13 ActivityCompat with v4 ActivityCompat.