### PR TITLE
Force reload MapListView

### DIFF
--- a/tables_app/src/main/java/org/opendatakit/tables/fragments/MapListViewFragment.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/fragments/MapListViewFragment.java
@@ -87,6 +87,8 @@ public class MapListViewFragment extends ListViewFragment implements IMapListVie
 
     OdkTablesWebView currentView = getWebKit();
     // reload the page.
+    // the webkit doesn't like to reload, convince it
+    currentView.setForceLoadDuringReload();
     currentView.reloadPage();
   }
 


### PR DESCRIPTION
Fixes opendatakit/opendatakit#1383

setForceLoadDuringReload to make sure the webkit actually gets reloaded. The reloading is necessary for the JS side to be notified of a marker selection. 