### PR TITLE
Fix widget create

### DIFF
--- a/tables_app/src/main/AndroidManifest.xml
+++ b/tables_app/src/main/AndroidManifest.xml
@@ -84,8 +84,8 @@
         <activity android:name=".activities.ExportCSVActivity"/>
         <activity
                 android:name=".activities.AndroidShortcuts"
-                android:label="@string/shortcut_name">
-            <!--android:theme="@android:style/Theme.Translucent.NoTitleBar" > -->
+                android:label="@string/shortcut_name"
+                android:theme="@style/Theme.AppCompat.Light.Dialog" >
             <intent-filter>
                 <action android:name="android.intent.action.CREATE_SHORTCUT"/>
                 <category android:name="android.intent.category.DEFAULT"/>

--- a/tables_app/src/main/AndroidManifest.xml
+++ b/tables_app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
     <application
             android:name="org.opendatakit.tables.application.Tables"
             tools:replace="android:theme"
-            android:icon="@drawable/icon"
+            android:icon="@drawable/odk_tables_ab_icon"
             android:label="@string/app_name"
             android:logo="@drawable/odk_tables_ab_icon"
             android:theme="@style/Opendatakit"


### PR DESCRIPTION
1. Fix Tables icon shown in Android's widget selector. It was showing a generic Android icon. 
2. Use the same theme for AndroidShortcuts activity in Survey and Tables, to give a more consistent look. 