### PR TITLE
fixing the Issue of Uri.parse

### DIFF
--- a/tables_app/src/main/java/org/opendatakit/tables/activities/ImportCSVActivity.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/activities/ImportCSVActivity.java
@@ -279,8 +279,8 @@ public class ImportCSVActivity extends AbsBaseActivity {
     @Override
     public void onClick(View v) {
       Intent intent = new Intent("org.openintents.action.PICK_FILE");
-      intent.setData(Uri.parse("file://" + ODKFileUtils.getAssetsCsvFolder(appName)));
       intent.putExtra("org.openintents.extra.TITLE_KEY", title);
+      intent.putExtra("org.openintents.extra.DIR_PATH", ODKFileUtils.getAssetsCsvFolder(appName));
       try {
         startActivityForResult(intent, 1);
       } catch (ActivityNotFoundException e) {


### PR DESCRIPTION
fixing the Issue of Uri.parse not working in Android version greater than N.
Using org.openintents.extra.DIR_PATH