### PR TITLE
Swap fragment in MainActivity after sync by custom home

### DIFF
--- a/tables_app/src/main/java/org/opendatakit/tables/activities/MainActivity.java
+++ b/tables_app/src/main/java/org/opendatakit/tables/activities/MainActivity.java
@@ -274,7 +274,27 @@ public class MainActivity extends AbsBaseWebActivity
 
   @Override
   public void initializationCompleted() {
-    popBackStack();
+    File newHome = getHomeScreen(null);
+
+    if ((newHome == null && webFileToDisplay == null) ||
+            (newHome != null && webFileToDisplay != null)) {
+      // no change to existence of custom home, return to the previous fragment
+      popBackStack();
+    } else {
+      // swap to webview if custom home was added
+      // swap to table manager if custom home was removed
+
+      webFileToDisplay = newHome;
+      // immediate because swapScreens operates on the back stack
+      getSupportFragmentManager().popBackStackImmediate(
+              null, FragmentManager.POP_BACK_STACK_INCLUSIVE);
+
+      if (newHome != null) {
+        swapScreens(ScreenType.WEBVIEW_SCREEN);
+      } else {
+        swapScreens(ScreenType.TABLE_MANAGER_SCREEN);
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
Fixes https://github.com/opendatakit/tool-suite-X/issues/60

This pull request adds a check for custom home screen in MainActivity's initialization callback. If a custom home screen was added, MainActivity will swapScreens to the webview fragment. If a custom home screen was removed, MainActivity will swapScreens to the table manager fragment.

Previously, the custom home screen check was only done in onCreate of MainActivity, which is insufficient to account for syncs launched from Tables.