### PR TITLE
 added the icon on drawable-night to support dark mode

### DIFF
--- a/tables_app/src/main/res/drawable/ic_add_black_24dp.xml
+++ b/tables_app/src/main/res/drawable/ic_add_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/tables_app/src/main/res/drawable/ic_archive_black_24dp.xml
+++ b/tables_app/src/main/res/drawable/ic_archive_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20.54,5.23l-1.39,-1.68C18.88,3.21 18.47,3 18,3H6c-0.47,0 -0.88,0.21 -1.16,0.55L3.46,5.23C3.17,5.57 3,6.02 3,6.5V19c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V6.5c0,-0.48 -0.17,-0.93 -0.46,-1.27zM12,17.5L6.5,12H10v-2h4v2h3.5L12,17.5zM5.12,5l0.81,-1h12l0.94,1H5.12z"/>
+</vector>

--- a/tables_app/src/main/res/drawable/ic_forward_black_24dp.xml
+++ b/tables_app/src/main/res/drawable/ic_forward_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,8V4l8,8 -8,8v-4H4V8z"/>
+</vector>

--- a/tables_app/src/main/res/drawable/ic_mode_edit_black_24dp.xml
+++ b/tables_app/src/main/res/drawable/ic_mode_edit_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+</vector>

--- a/tables_app/src/main/res/drawable/ic_search_black_24dp.xml
+++ b/tables_app/src/main/res/drawable/ic_search_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="36dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+</vector>

--- a/tables_app/src/main/res/drawable/ic_sort_black_24dp.xml
+++ b/tables_app/src/main/res/drawable/ic_sort_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="36dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M3,18h6v-2L3,16v2zM3,6v2h18L21,6L3,6zM3,13h12v-2L3,11v2z"/>
+</vector>

--- a/tables_app/src/main/res/drawable/ic_unarchive_black_24dp.xml
+++ b/tables_app/src/main/res/drawable/ic_unarchive_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20.55,5.22l-1.39,-1.68C18.88,3.21 18.47,3 18,3H6C5.53,3 5.12,3.21 4.85,3.55L3.46,5.22C3.17,5.57 3,6.01 3,6.5V19c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V6.5C21,6.01 20.83,5.57 20.55,5.22zM12,9.5l5.5,5.5H14v2h-4v-2H6.5L12,9.5zM5.12,5l0.82,-1h12l0.93,1H5.12z"/>
+</vector>

--- a/tables_app/src/main/res/drawable/ic_view_headline_black_24dp.xml
+++ b/tables_app/src/main/res/drawable/ic_view_headline_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M4,15h16v-2L4,13v2zM4,19h16v-2L4,17v2zM4,11h16L20,9L4,9v2zM4,5v2h16L20,5L4,5z"/>
+</vector>


### PR DESCRIPTION
### This is the complementary PR to this [pull request ](https://github.com/odk-x/androidlibrary/pull/236)   to address the issuse of  [Table Set the status bar color #364 ](https://github.com/odk-x/tool-suite-X/issues/364)  in order to support night mode properly.

#### Here , following changes has been made :
- #### Added the drawable-night folder for the night mode .
-  #### Added the images of svg ( .xml extension )  inside the drawable-night folder so that they are shown while changing into night mode .
### Verification example attached in the screenshots . 
![image](https://user-images.githubusercontent.com/25600880/197196789-c841d758-8c1e-4743-8ea9-a3862cc33aa9.png)

