### PR TITLE
Remove successful pipeline requirement when getting artifacts in config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
             
             # Make the API request to get the pipelines of the repository
             PIPELINES_RESPONSE=$(
-            curl --location --request GET "https://circleci.com/api/v2/project/github/${CIRCLE_USERNAME}/${REPO_NAME}/pipeline?branch=${BRANCH}&status=success" \
+            curl --location --request GET "https://circleci.com/api/v2/project/github/${CIRCLE_USERNAME}/${REPO_NAME}/pipeline?branch=${BRANCH}" \
              --header 'Content-Type: application/json' \
               -u "${CIRCLECI_TOKEN}:" \
             ) 


### PR DESCRIPTION
I think I figured out why the tables test fails at the Get Artifacts step.

That's because I set a requirement when getting the artifacts to get only for the pipelines which have been successful (including building and testing). Since we are still having issues the testing it disregards the failing pipelines and hence doesn't actually find any successful pipeline to get the artifacts from.

I have removed that requirement. so even if a pipeline fails, as long as the `build` job passes it should get the artifacts from that job, in theory.